### PR TITLE
Operator registration Form - Japanese translation and Validation 

### DIFF
--- a/RegisVac/settings.py
+++ b/RegisVac/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'knu6@q#hyr79f%9wv(6hug@lh=wg(f#razynclxcxou7%doaxt'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['127.0.0.1']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 
 
 # Application definition

--- a/RegisVac/settings.py
+++ b/RegisVac/settings.py
@@ -55,6 +55,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
 ]
 
 ROOT_URLCONF = 'RegisVac.urls'

--- a/main/forms/operator/forms.py
+++ b/main/forms/operator/forms.py
@@ -1,11 +1,116 @@
 # -*- coding: utf-8 -*-
 # Project: RegisVac
+import re
 
+from django.contrib.auth import password_validation
 from django.contrib.auth.models import Group, User
 from django.contrib.auth.forms import UserCreationForm
 from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.html import format_html_join, format_html
 
 from main.models import Operator
+
+
+def jp_password1_help_text():
+    help_texts = ['パスワードは他の個人情報と類似していないものにしてください。', 'パスワードは8文字以上である必要があります。',
+                  'パスワードは一般的に使用されていないものにしなければなりません。', 'パスワードをすべて数字のみにすることはできません。']
+    help_items = format_html_join('', '<li class="error">{}</li>', ((help_text,) for help_text in help_texts))
+    return format_html('<ul>{}</ul>', help_items) if help_items else ''
+
+
+class JPUserCreationForm(UserCreationForm):
+    class Meta(UserCreationForm):
+        model = User
+        fields = ['id', 'username', 'first_name', 'last_name', 'email', 'is_staff']
+        labels = {
+            'username': 'ユーザー名 [必須]',
+            'first_name': '姓',
+            'last_name': '名',
+            'email': 'メールアドレス',
+            'is_staff': 'あなたはスタッフですか?',
+        }
+        help_texts = {
+            'username': 'ユーザー名は150文字以下で、文字、数字、記号 @ / . / + / - / _ のみ使用できます。',
+            'is_staff': 'ユーザーがこの管理サイトにログインできるかどうかを指定します。',
+        }
+        error_messages = {
+            'username': {
+                'invaild_username_length': 'ユーザー名は150文字以下のものを入力してください。',
+                'invalid_format_username': 'ユーザー名には 文字、数字、記号 @ / . / + / - / _ のみ使用できます。',
+            },
+            'email': {
+                'invalid_format_email': 'メールアドレスの入力に誤りがあります。',
+            },
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # ラベルを日本語化
+        self.fields['password1'].label = 'パスワード [必須]'
+        self.fields['password2'].label = '確認用パスワード [必須]'
+
+        # エラーメッセージを日本語化
+        self.error_messages['password_mismatch'] = '入力された2つのパスワードが一致しません。'
+
+        # ヘルプテキストを日本語化
+        self.fields['password1'].help_text = jp_password1_help_text()
+        self.fields['password2'].help_text = '確認のため、もう一度パスワードを入力してください。'
+
+    def clean_username(self):
+        username = self.cleaned_data.get("username")
+
+        if (len(username) > 150 or len(username) <= 0):
+            raise ValidationError(
+                self.error_messages['invaild_username_length'],
+                code='invaild_username_length',
+            )
+        if not re.search(r"[\w\d@.+-]+", username):
+            raise ValidationError(
+                self.error_messages['invalid_format_username'],
+                code='invalid_format_username',
+            )
+
+        return username
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+
+        if email and not re.match(r"^[\w\-.]+@[\w\-.]+\.[A-Za-z]+$", email):
+            raise ValidationError(
+                self.error_messages['invalid_format_email'],
+                code='invalid_format_email',
+            )
+
+        return email
+
+    def clean_password2(self):
+        password1 = self.cleaned_data.get("password1")
+        password2 = self.cleaned_data.get("password2")
+        if password1 and password2 and password1 != password2:
+            raise ValidationError(
+                self.error_messages['password_mismatch'],
+                code='password_mismatch',
+            )
+        return password2
+
+    def _post_clean(self):
+        super()._post_clean()
+        # Validate the password after self.instance is updated with form data
+        # by super().
+        password = self.cleaned_data.get('password2')
+        if password:
+            try:
+                password_validation.validate_password(password, self.instance)
+            except ValidationError as error:
+                self.add_error('password1', error)
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.set_password(self.cleaned_data["password1"])
+        if commit:
+            user.save()
+        return user
 
 
 class MyUserCreationForm(UserCreationForm):
@@ -27,7 +132,7 @@ class OperatorCreationForm(forms.ModelForm):
 
     auth_group = forms.ModelChoiceField(
         label="役割",
-        queryset=Group.objects.exclude(id=1),    # adminを除外する
+        queryset=Group.objects.exclude(id=1),  # adminを除外する
     )
 
 
@@ -36,4 +141,3 @@ class OperatorRemoveForm(forms.ModelForm):
     class Meta:
         model = Operator
         fields = ['id']
-

--- a/main/forms/operator/forms.py
+++ b/main/forms/operator/forms.py
@@ -84,34 +84,6 @@ class JPUserCreationForm(UserCreationForm):
 
         return email
 
-    def clean_password2(self):
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-        if password1 and password2 and password1 != password2:
-            raise ValidationError(
-                self.error_messages['password_mismatch'],
-                code='password_mismatch',
-            )
-        return password2
-
-    def _post_clean(self):
-        super()._post_clean()
-        # Validate the password after self.instance is updated with form data
-        # by super().
-        password = self.cleaned_data.get('password2')
-        if password:
-            try:
-                password_validation.validate_password(password, self.instance)
-            except ValidationError as error:
-                self.add_error('password1', error)
-
-    def save(self, commit=True):
-        user = super().save(commit=False)
-        user.set_password(self.cleaned_data["password1"])
-        if commit:
-            user.save()
-        return user
-
 
 class MyUserCreationForm(UserCreationForm):
     class Meta(UserCreationForm):

--- a/main/views/operator/views.py
+++ b/main/views/operator/views.py
@@ -7,7 +7,7 @@ from django.views.generic.edit import CreateView, UpdateView
 from django.contrib.auth.models import Group, User
 from django.contrib.auth.mixins import LoginRequiredMixin
 
-from main.forms.operator.forms import MyUserCreationForm, OperatorCreationForm, OperatorRemoveForm
+from main.forms.operator.forms import MyUserCreationForm, OperatorCreationForm, OperatorRemoveForm, JPUserCreationForm
 
 app_name = 'main'
 
@@ -24,7 +24,7 @@ class OperatorListView(LoginRequiredMixin, generic.ListView):
 # まっさらな状態
 class OperatorCreateView(CreateView):
     model = User
-    form_class = MyUserCreationForm
+    form_class = JPUserCreationForm
     template_name = "main/operator/operator_form.html"
     success_url = reverse_lazy('main:operator_list')
 
@@ -32,7 +32,7 @@ class OperatorCreateView(CreateView):
 # 更新画面
 class OperatorUpdateView(UpdateView):
     model = User
-    form_class = MyUserCreationForm
+    form_class = JPUserCreationForm
     template_name = "main/operator/operator_form.html"
     success_url = reverse_lazy('main:operator_list')
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,9 +22,7 @@
         {% block extra_css %}{% endblock %}
     </style>
     <script language="javascript" type="text/javascript">
-    <!--
         {% block extra_javascript %}{% endblock %}
-    // -->
     </script>
 </head>
 

--- a/templates/main/operator/operator_form.html
+++ b/templates/main/operator/operator_form.html
@@ -3,6 +3,12 @@
 {% extends "base.html" %}
 {% block title %}操作者登録画面-RegisVac{% endblock %}
 
+{% block extra_css %}
+    ul.errorlist *{
+    color: red;
+    }
+{% endblock %}
+
 {% block content %}
     <div class="container">
         <h4 class="mt-4 border-bottom">操作者登録画面</h4>


### PR DESCRIPTION
・操作者登録画面の日本語対応、バリデーション機能の追加を行いました

実装としては、main/forms/operator/forms.py に、
JPUserCreationForm クラスを作成し、MyUserCreationForm クラスの代わりに使用しています。

主な変更内容は以下の通りです。

〇RegisVac/settings.py
django.middleware.locale.LocaleMiddleware を追加し、翻訳を行うように変更しています。
JPUserCreationForm クラスの追加では、UserCreationForm で用意されているバリデーションによる
英語のエラーメッセージを日本語化することは困難に思われたので、翻訳機能を利用することにしました。

〇main/forms/operator/forms.py
・JPUserCreationForm クラスのコンストラクタと内部クラスである Metaクラスで
labels, help_text, error_message の日本語化をしています。
・JPUserCreationForm クラスのメソッド clean_username, clean_email で、
 username, email に対し、正規表現でバリデーションをしています。

〇main/views/operator/views.py
form_class を MyUserCreationForm クラスから JPUserCreationForm クラスに変更しています。

〇templates/base.html
HTML コメントを削除

〇templates/main/operator/operator_form.html
extra_css ブロックを作成し、操作者登録画面のエラーメッセージを赤字で表示するためのCSSを作成

